### PR TITLE
Python code refactoring.

### DIFF
--- a/.vscode/setup.sh
+++ b/.vscode/setup.sh
@@ -40,9 +40,29 @@ if ! test -f "$CLI_INSTALLED"; then
     if [[ "$run_cli_script" =~ "n" ]]; then
         echo "You have chosen to not install the Decky CLI tool to build your plugins. Please install this tool to build and test your plugin before submitting it to the Plugin Database."
     else
-        mkdir $(pwd)/cli
-        curl -L -o $(pwd)/cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/latest/download/decky"
-        chmod +x $(pwd)/cli/decky
+
+        SYSTEM_ARCH="$(uname -a)"
+
+        mkdir "$(pwd)"/cli
+        if [[ "$SYSTEM_ARCH" =~ "x86_64" ]]; then
+
+            if [[ "$SYSTEM_ARCH" =~ "Linux" ]]; then
+                curl -L -o "$(pwd)"/cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/latest/download/decky-linux-x86_64"
+            fi
+
+            if [[ "$SYSTEM_ARCH" =~ "Darwin" ]]; then
+                curl -L -o "$(pwd)"/cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/latest/download/decky-macOS-x86_64"
+            fi
+
+        else
+            echo "System Arch not found! The only supported systems are Linux x86_64 and Apple x86_64/ARM64, not $SYSTEM_ARCH"
+        fi
+
+        if [[ "$SYSTEM_ARCH" =~ "arm64" ]]; then
+            curl -L -o "$(pwd)"/cli/decky "https://github.com/SteamDeckHomebrew/cli/releases/latest/download/decky-macOS-aarch64"
+        fi
+
+        chmod +x "$(pwd)"/cli/decky
         echo "Decky CLI tool is now installed and you can build plugins into easy zip files using the "Build Zip" Task in vscodium."
     fi
 fi

--- a/defaults/py_modules/decky_terminal/__init__.py
+++ b/defaults/py_modules/decky_terminal/__init__.py
@@ -1,13 +1,16 @@
+import asyncio
+import json
+import os
+import platform
+import random
+from typing import Any, Dict, List, Optional
+
 from decky_plugin import DECKY_PLUGIN_SETTINGS_DIR
 from websockets import server
-import random
-import asyncio
-from .terminal import Terminal
-from typing import Any, List, Dict, Optional, TypeVar, Callable
-import platform
-import json
+
 from .common import Common
-import os
+from .terminal import Terminal
+
 
 class DeckyTerminal:
     _bind_address = "127.0.0.1"

--- a/defaults/py_modules/decky_terminal/__init__.py
+++ b/defaults/py_modules/decky_terminal/__init__.py
@@ -3,6 +3,7 @@ import json
 import os
 import platform
 import random
+import uuid
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
@@ -117,12 +118,14 @@ class DeckyTerminal:
         return flags
 
     # TERMINAL CREATION =====================================
-    async def create_terminal(self, terminal_id: str, cmdline: Optional[str] = None):
+    async def create_terminal(self, terminal_id: str = None, cmdline: Optional[str] = None):
         if cmdline is None:
             cmdline = await self.get_default_shell()
 
-        print("cmdline!!!!", cmdline)
         flags = await self._get_terminal_flags()
+
+        if terminal_id is None:
+            terminal_id = str(uuid.uuid4())
 
         if self._terminal_sessions.get(terminal_id) is None:
             self._terminal_sessions[terminal_id] = Terminal(cmdline, **flags)

--- a/defaults/py_modules/decky_terminal/__init__.py
+++ b/defaults/py_modules/decky_terminal/__init__.py
@@ -49,7 +49,7 @@ class DeckyTerminal:
             return ["/bin/sh"]
 
     def _is_unix_shell_path(self, path: str) -> bool:
-        return len(path) > 0 and path.startswith("/") and not path.isspace()
+        return path.startswith("/")
 
     # CONFIG ================================================
     def get_config_filename(self) -> str:

--- a/defaults/py_modules/decky_terminal/__init__.py
+++ b/defaults/py_modules/decky_terminal/__init__.py
@@ -29,36 +29,36 @@ class DeckyTerminal:
     # GET_FETCH =============================================
     def is_running(self):
         return self._server_port > 0
-    
+
     def get_server_port(self):
         return self._server_port
 
     # GET_SHELL =============================================
     async def get_shells(self) -> List[str]:
-        if platform.system() == 'Windows':
+        if platform.system() == "Windows":
             return ["powershell", "cmd"]
         else:
             try:
                 data = await Common.read_file("/etc/shells")
                 if data is None:
                     raise IOError()
-                
+
                 shells = data.splitlines()
                 shells = list(filter(self._is_unix_shell_path, shells))
                 if len(shells) < 1:
                     return ["/bin/sh"]
-                
+
                 return shells
             except:
                 return ["/bin/sh"]
-    
+
     def _is_unix_shell_path(self, path: str) -> bool:
         return len(path) > 0 and path.startswith("/") and not path.isspace()
- 
+
     # CONFIG ================================================
     def get_config_filename(self) -> str:
-        return DECKY_PLUGIN_SETTINGS_DIR+os.sep+"config.json"
-    
+        return DECKY_PLUGIN_SETTINGS_DIR + os.sep + "config.json"
+
     async def get_config(self) -> dict:
         config = await self._get_config()
         if config is None:
@@ -75,7 +75,7 @@ class DeckyTerminal:
             prev_config = dict(
                 __version__=1,
             )
-        
+
         config = Common.merge_dict(prev_config, new_config)
         return await self._write_config(config)
 
@@ -84,30 +84,30 @@ class DeckyTerminal:
 
         if config is None:
             return (await self.get_shells())[0]
-        
-        shell = config.get('default_shell')
+
+        shell = config.get("default_shell")
         if shell is None:
             return (await self.get_shells())[0]
 
         return shell
-    
+
     async def set_default_shell(self, shell: str) -> bool:
-        return await self.append_config(dict( default_shell=shell ))
- 
+        return await self.append_config(dict(default_shell=shell))
+
     # CONFIG - INTERNAL =======================================
     async def _get_config(self) -> Optional[dict]:
         try:
             data = await Common.read_file(self.get_config_filename())
             if data is None:
                 raise IOError()
-            
+
             return json.loads(data)
         except IOError:
             return None
-        
+
     async def _write_config(self, config: dict) -> bool:
-        return await Common.write_file(self.get_config_filename (), json.dumps(config))
-    
+        return await Common.write_file(self.get_config_filename(), json.dumps(config))
+
     async def _get_terminal_flags(self) -> dict:
         flags = dict()
         config = await self._get_config()
@@ -125,29 +125,29 @@ class DeckyTerminal:
         if cmdline is None:
             cmdline = await self.get_default_shell()
 
-        print('cmdline!!!!', cmdline)
+        print("cmdline!!!!", cmdline)
         flags = await self._get_terminal_flags()
 
         if self._terminal_sessions.get(id) is None:
             self._terminal_sessions[id] = Terminal(cmdline, **flags)
-    
+
     async def remove_terminal(self, id: str):
         if self._terminal_sessions.get(id) is not None:
             terminal: Terminal = self._terminal_sessions[id]
             await terminal.shutdown()
             del self._terminal_sessions[id]
-    
+
     def get_terminal(self, id) -> Optional[Terminal]:
         return self._terminal_sessions.get(id)
-    
+
     def get_terminal_ids(self) -> List[str]:
         return self._terminal_sessions.keys()
-    
+
     def set_terminal_title(self, id, title):
         term = self.get_terminal(id)
         if term is not None:
             term.title = title
-    
+
     def get_terminals(self) -> Dict[str, Terminal]:
         return self._terminal_sessions
 
@@ -155,14 +155,14 @@ class DeckyTerminal:
     async def start_server(self) -> bool:
         if self.is_running():
             return False
-        
+
         await self._start_server()
         asyncio.ensure_future(self._server_wait(), loop=self._event_loop)
 
     async def stop_server(self) -> bool:
         if not self.is_running():
             return False
-        
+
         await self._kill_all_terminals()
         self._server_cleanup()
         self._server_port = -1
@@ -173,7 +173,7 @@ class DeckyTerminal:
             splitted = path.split("?", 1)
 
             target_path = splitted[0]
-            
+
             # TODO: This parsing mechanism sucks - make it better
             terminal_id = target_path.replace("/v1/terminals/", "", 1)
             return await self.terminal_handler(ws, terminal_id)
@@ -181,7 +181,7 @@ class DeckyTerminal:
             return await self.echo_handler(ws)
         else:
             await ws.close()
-        
+
     async def terminal_handler(self, ws: server.WebSocketServerProtocol, id: str):
         terminal = self.get_terminal(id)
 
@@ -191,7 +191,6 @@ class DeckyTerminal:
             await terminal._remove_subscriber(ws)
         else:
             await ws.close()
-
 
     async def echo_handler(self, ws: server.WebSocketServerProtocol):
         while not ws.closed:
@@ -219,7 +218,7 @@ class DeckyTerminal:
         ws_server = await server.serve(self.handler, self._bind_address, port)
         self._server_port = port
         self._server = ws_server
-    
+
     async def _server_wait(self):
         future = asyncio.Future(loop=self._event_loop)
         self._server_future = future
@@ -230,7 +229,7 @@ class DeckyTerminal:
         if self._server_future is not None:
             self._server_future.done()
             self._server_future = None
-        
+
         if self._server is not None:
             self._server.close()
             self._server = None
@@ -238,4 +237,3 @@ class DeckyTerminal:
     # UTILS =====================================================================
     def _get_random_port(self) -> int:
         return random.randint(10000, 19999)
-

--- a/defaults/py_modules/decky_terminal/__init__.py
+++ b/defaults/py_modules/decky_terminal/__init__.py
@@ -53,7 +53,7 @@ class DeckyTerminal:
 
     # CONFIG ================================================
     def get_config_filename(self) -> str:
-        return DECKY_PLUGIN_SETTINGS_DIR + os.sep + "config.json"
+        return os.path.join(DECKY_PLUGIN_SETTINGS_DIR, "config.json")
 
     async def get_config(self) -> dict:
         config = await self._get_config()

--- a/defaults/py_modules/decky_terminal/__init__.py
+++ b/defaults/py_modules/decky_terminal/__init__.py
@@ -115,7 +115,7 @@ class DeckyTerminal:
         if config is not None:
             if config.get("use_display") is not None:
                 use_display = config.get("use_display")
-                if type(use_display) == bool:
+                if isinstance(use_display, bool):
                     flags["use_display"] = use_display
 
         return flags

--- a/defaults/py_modules/decky_terminal/__init__.py
+++ b/defaults/py_modules/decky_terminal/__init__.py
@@ -4,6 +4,7 @@ import os
 import platform
 import random
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 from decky_plugin import DECKY_PLUGIN_SETTINGS_DIR
 from websockets import server
@@ -170,12 +171,8 @@ class DeckyTerminal:
     # SERVER HANDLER ========================================
     async def handler(self, ws: server.WebSocketServerProtocol, path: str):
         if path.startswith("/v1/terminals/"):
-            splitted = path.split("?", 1)
-
-            target_path = splitted[0]
-
-            # TODO: This parsing mechanism sucks - make it better
-            terminal_id = target_path.replace("/v1/terminals/", "", 1)
+            url = urlparse(path)
+            terminal_id = url.path.split("/")[-1]
             return await self.terminal_handler(ws, terminal_id)
         elif path == "/echo":
             return await self.echo_handler(ws)

--- a/defaults/py_modules/decky_terminal/__init__.py
+++ b/defaults/py_modules/decky_terminal/__init__.py
@@ -121,30 +121,30 @@ class DeckyTerminal:
         return flags
 
     # TERMINAL CREATION =====================================
-    async def create_terminal(self, id: str, cmdline: Optional[str] = None):
+    async def create_terminal(self, terminal_id: str, cmdline: Optional[str] = None):
         if cmdline is None:
             cmdline = await self.get_default_shell()
 
         print("cmdline!!!!", cmdline)
         flags = await self._get_terminal_flags()
 
-        if self._terminal_sessions.get(id) is None:
-            self._terminal_sessions[id] = Terminal(cmdline, **flags)
+        if self._terminal_sessions.get(terminal_id) is None:
+            self._terminal_sessions[terminal_id] = Terminal(cmdline, **flags)
 
-    async def remove_terminal(self, id: str):
-        if self._terminal_sessions.get(id) is not None:
-            terminal: Terminal = self._terminal_sessions[id]
+    async def remove_terminal(self, terminal_id: str):
+        if self._terminal_sessions.get(terminal_id) is not None:
+            terminal: Terminal = self._terminal_sessions[terminal_id]
             await terminal.shutdown()
-            del self._terminal_sessions[id]
+            del self._terminal_sessions[terminal_id]
 
-    def get_terminal(self, id) -> Optional[Terminal]:
-        return self._terminal_sessions.get(id)
+    def get_terminal(self, terminal_id) -> Optional[Terminal]:
+        return self._terminal_sessions.get(terminal_id)
 
     def get_terminal_ids(self) -> List[str]:
         return self._terminal_sessions.keys()
 
-    def set_terminal_title(self, id, title):
-        term = self.get_terminal(id)
+    def set_terminal_title(self, terminal_id, title):
+        term = self.get_terminal(terminal_id)
         if term is not None:
             term.title = title
 
@@ -182,8 +182,8 @@ class DeckyTerminal:
         else:
             await ws.close()
 
-    async def terminal_handler(self, ws: server.WebSocketServerProtocol, id: str):
-        terminal = self.get_terminal(id)
+    async def terminal_handler(self, ws: server.WebSocketServerProtocol, terminal_id: str):
+        terminal = self.get_terminal(terminal_id)
 
         if terminal is not None:
             terminal.add_subscriber(ws)

--- a/defaults/py_modules/decky_terminal/__init__.py
+++ b/defaults/py_modules/decky_terminal/__init__.py
@@ -173,7 +173,6 @@ class DeckyTerminal:
             splitted = path.split("?", 1)
 
             target_path = splitted[0]
-            query_string = None if len(splitted) == 1 else splitted[1]
             
             # TODO: This parsing mechanism sucks - make it better
             terminal_id = target_path.replace("/v1/terminals/", "", 1)

--- a/defaults/py_modules/decky_terminal/__init__.py
+++ b/defaults/py_modules/decky_terminal/__init__.py
@@ -12,6 +12,7 @@ from websockets import server
 
 from .common import Common
 from .terminal import Terminal
+from .nato import phoneticize
 
 
 class DeckyTerminal:
@@ -129,6 +130,7 @@ class DeckyTerminal:
 
         if self._terminal_sessions.get(terminal_id) is None:
             self._terminal_sessions[terminal_id] = Terminal(cmdline, **flags)
+            self._terminal_sessions[terminal_id].title = phoneticize(terminal_id[0:4])
 
     async def remove_terminal(self, terminal_id: str):
         if self._terminal_sessions.get(terminal_id) is not None:

--- a/defaults/py_modules/decky_terminal/__init__.py
+++ b/defaults/py_modules/decky_terminal/__init__.py
@@ -39,19 +39,14 @@ class DeckyTerminal:
         if platform.system() == "Windows":
             return ["powershell", "cmd"]
         else:
-            try:
-                data = await Common.read_file("/etc/shells")
-                if data is None:
-                    raise IOError()
-
+            data = await Common.read_file("/etc/shells")
+            if data is not None:
                 shells = data.splitlines()
                 shells = list(filter(self._is_unix_shell_path, shells))
-                if len(shells) < 1:
-                    return ["/bin/sh"]
+                if shells:
+                    return shells
 
-                return shells
-            except:
-                return ["/bin/sh"]
+            return ["/bin/sh"]
 
     def _is_unix_shell_path(self, path: str) -> bool:
         return len(path) > 0 and path.startswith("/") and not path.isspace()

--- a/defaults/py_modules/decky_terminal/common.py
+++ b/defaults/py_modules/decky_terminal/common.py
@@ -39,7 +39,7 @@ class Common:
             if prev.get(i) is None:
                 prev[i] = v
             else:
-                if type(prev.get(i)) is dict and type(v) is dict:
+                if isinstance(prev.get(i), dict) and isinstance(v, dict):
                     prev[i] = cls.merge_dict(prev[i], new[i])
                 else:
                     prev[i] = v

--- a/defaults/py_modules/decky_terminal/common.py
+++ b/defaults/py_modules/decky_terminal/common.py
@@ -5,6 +5,7 @@ from typing import Callable, Dict, Optional, TypeVar
 _T = TypeVar("_T")
 _U = TypeVar("_U")
 
+
 class Common:
     @classmethod
     async def _run_async(cls, fun: Callable[..., _T], *args) -> _T:
@@ -19,7 +20,7 @@ class Common:
             f.close()
             return data
         except Exception as e:
-            print('exception', e)
+            print("exception", e)
             return None
 
     @classmethod
@@ -30,9 +31,9 @@ class Common:
             f.close()
             return True
         except Exception as e:
-            print('exception', e)
+            print("exception", e)
             return False
-        
+
     @classmethod
     def merge_dict(cls, prev: Dict[_T, _U], new: Dict[_T, _U]) -> Dict[_T, _U]:
         for i, v in new.items():
@@ -43,5 +44,5 @@ class Common:
                     prev[i] = cls.merge_dict(prev[i], new[i])
                 else:
                     prev[i] = v
-        
+
         return prev

--- a/defaults/py_modules/decky_terminal/common.py
+++ b/defaults/py_modules/decky_terminal/common.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import List, Dict, Optional, TypeVar, Callable
+from typing import Callable, Dict, Optional, TypeVar
 
 # Why does the Python generic work this way?
 _T = TypeVar("_T")

--- a/defaults/py_modules/decky_terminal/nato.py
+++ b/defaults/py_modules/decky_terminal/nato.py
@@ -1,0 +1,51 @@
+ALPHABET = [
+    "Alfa",
+    "Bravo",
+    "Charlie",
+    "Delta",
+    "Echo",
+    "Foxtrot",
+    "Golf",
+    "Hotel",
+    "India",
+    "Juliett",
+    "Kilo",
+    "Lima",
+    "Mike",
+    "November",
+    "Oscar",
+    "Papa",
+    "Quebec",
+    "Romeo",
+    "Sierra",
+    "Tango",
+    "Uniform",
+    "Victor",
+    "Whiskey",
+    "Xray",
+    "Yankee",
+    "Zulu"
+]
+
+NUMBERS = [
+    "Zero",
+    "One",
+    "Two",
+    "Three",
+    "Four",
+    "Five",
+    "Six",
+    "Seven",
+    "Eight",
+    "Niner"
+]
+
+def phoneticize(data: str, sep: str = ""):
+    data = data.lower()
+    output = []
+    for char in data:
+        try:
+            output.append(NUMBERS[int(char)])
+        except ValueError:
+            output.append(ALPHABET[ord(char) - ord("a")])
+    return sep.join(output)

--- a/defaults/py_modules/decky_terminal/terminal.py
+++ b/defaults/py_modules/decky_terminal/terminal.py
@@ -120,7 +120,7 @@ class Terminal:
 
     # PROCESS CONTROL =======================================
     def get_terminal_env(self):
-        result = dict(**os.environ)
+        result = dict(os.environ)
         result["TERM"] = "xterm-256color"
         result["PWD"] = result["HOME"]
         result["SSH_TTY"] = os.ttyname(self.slave_fd)

--- a/defaults/py_modules/decky_terminal/terminal.py
+++ b/defaults/py_modules/decky_terminal/terminal.py
@@ -121,12 +121,15 @@ class Terminal:
     # PROCESS CONTROL =======================================
     def get_terminal_env(self):
         result = dict(os.environ)
-        result["TERM"] = "xterm-256color"
-        result["PWD"] = result["HOME"]
-        result["SSH_TTY"] = os.ttyname(self.slave_fd)
-        result["LINES"] = str(self.rows)
-        result["COLUMNS"] = str(self.cols)
-        result["XDG_RUNTIME_DIR"] = "/run/user/" + str(os.getuid())
+
+        result.update({
+            "TERM": "xterm-256color",
+            "PWD": result["HOME"],
+            "SSH_TTY": os.ttyname(self.slave_fd),
+            "LINES": str(self.rows),
+            "COLUMNS": str(self.cols),
+            "XDG_RUNTIME_DIR": f"/run/user/{os.getuid()}"
+        })
 
         if self.cmdline is not None and self.is_shell:
             result["SHELL"] = self.cmdline

--- a/defaults/py_modules/decky_terminal/terminal.py
+++ b/defaults/py_modules/decky_terminal/terminal.py
@@ -107,7 +107,7 @@ class Terminal:
         while not ws.closed:
             try:
                 data = await ws.recv()
-                if type(data) == str:
+                if isinstance(data, str):
                     data = bytes(data, 'utf-8')
 
                 await self._write_stdin(data)
@@ -129,7 +129,7 @@ class Terminal:
         if self.cmdline is not None and self.is_shell:
             result["SHELL"] = self.cmdline
 
-        if self.flags.get("use_display") == True:
+        if self.flags.get("use_display"):
             result["DISPLAY"] = ":0"
 
         return result

--- a/defaults/py_modules/decky_terminal/terminal.py
+++ b/defaults/py_modules/decky_terminal/terminal.py
@@ -44,11 +44,11 @@ class Terminal:
         self.flags = kwargs
 
     def _calculate_sync_size(self):
-        min = self.cols * self.rows
-        if min < 1000:
+        size = self.cols * self.rows
+        if size < 1000:
             return 1000
         else:
-            return min * 5
+            return size * 5
 
     # SERIALIZE ============================================
     def serialize(self) -> dict:

--- a/defaults/py_modules/decky_terminal/terminal.py
+++ b/defaults/py_modules/decky_terminal/terminal.py
@@ -1,15 +1,17 @@
+import asyncio
+import collections
 import fcntl
+import os
+import pty
 import signal
 import struct
-import subprocess
 import termios
 from typing import List, Optional
-import asyncio
+
 from websockets import WebSocketServerProtocol
-import collections
-import pty
-import os
+
 from .common import Common
+
 
 class Terminal:
     _sync_size: int = 1000

--- a/defaults/py_modules/decky_terminal/terminal.py
+++ b/defaults/py_modules/decky_terminal/terminal.py
@@ -6,7 +6,7 @@ import pty
 import signal
 import struct
 import termios
-from typing import List, Optional
+from typing import List
 
 from websockets import WebSocketServerProtocol
 
@@ -17,7 +17,7 @@ class Terminal:
     _sync_size: int = 1000
 
     is_shell: bool = True
-    cmdline: Optional[str]
+    cmdline: str = None
     process: asyncio.subprocess.Process = None
 
     master_fd: int
@@ -35,8 +35,7 @@ class Terminal:
     _title_cache: bytes = b""
 
     def __init__(self, cmdline: str, is_shell: bool = True, **kwargs):
-        if cmdline is not None:
-            self.cmdline = cmdline
+        self.cmdline = cmdline  # TODO: maybe raise ValueError? cmdline can't meaningfully be None or undefined since it must be available for _start_process
 
         self.is_shell = is_shell
         self.buffer = collections.deque([], maxlen=4096)

--- a/defaults/py_modules/decky_terminal/terminal.py
+++ b/defaults/py_modules/decky_terminal/terminal.py
@@ -63,9 +63,9 @@ class Terminal:
             if self.process.returncode is not None:
                 data["exitcode"] = self.process.returncode
 
-        if self.title is not None and self.title != "":
-            if not self.title.isspace():
-                data["title"] = self.title
+        # self.title is not None, whitespace or empty
+        if self.title is not None and self.title.strip():
+            data["title"] = self.title
 
         return data
 
@@ -82,7 +82,7 @@ class Terminal:
         if self._is_process_alive():
             await self._change_pty_size(rows, cols)
             await self.process.send_signal(signal.SIGWINCH)
-            await self._write_stdin(b"\x1b[8;%d;%dt" % (rows, cols))
+            await self._write_stdin(f"\x1b[8;{rows};{cols}t".encode("utf-8"))
 
     async def _change_pty_size(self, rows: int, cols: int):
         self.rows = rows
@@ -110,7 +110,7 @@ class Terminal:
             try:
                 data = await ws.recv()
                 if isinstance(data, str):
-                    data = bytes(data, "utf-8")
+                    data = data.encode("utf-8")
 
                 await self._write_stdin(data)
             except Exception as e:

--- a/defaults/py_modules/decky_terminal/terminal.py
+++ b/defaults/py_modules/decky_terminal/terminal.py
@@ -137,7 +137,6 @@ class Terminal:
 
     async def _start_process(self):
         self.master_fd, self.slave_fd = pty.openpty()
-        #self._set_pty_settings()
 
         await self._change_pty_size(self.rows, self.cols)
         self.process = await asyncio.create_subprocess_exec(
@@ -147,7 +146,6 @@ class Terminal:
             stderr=self.slave_fd,
             stdin=self.slave_fd,
             env=self.get_terminal_env(),
-            #creationflags=subprocess.CREATE_NO_WINDOW,
             cwd=os.getenv("HOME"),
         )
 

--- a/defaults/py_modules/decky_terminal/terminal.py
+++ b/defaults/py_modules/decky_terminal/terminal.py
@@ -204,22 +204,13 @@ class Terminal:
 
     # IS ALIVE ==============================================
     def _is_process_started(self):
-        if self.process is None:
-            return False
-
-        return True
+        return self.process is not None
 
     def _is_process_alive(self):
-        if not self._is_process_started():
-            return False
-
-        if self.process.returncode is not None:
-            return False
-
-        return True
+        return self._is_process_started() and self.process.returncode is None
 
     def _is_process_completed(self):
-        return not self._is_process_alive() and self._is_process_started()
+        return self._is_process_started() and self.process.returncode
 
     # PROCESS CONTROL =======================================
     async def _write_stdin(self, input: bytes):

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import random
 from typing import List, Optional
 from decky_terminal import DeckyTerminal
 
+
 class Plugin:
     decky_terminal = DeckyTerminal()
 
@@ -17,27 +18,29 @@ class Plugin:
 
         for id, terminal in terminals.items():
             result = terminal.serialize()
-            output.append(dict(
-                id=id,
-                **result,
-            ))
-        
+            output.append(
+                dict(
+                    id=id,
+                    **result,
+                )
+            )
+
         return output
 
     async def get_terminal(self, id: str) -> Optional[dict]:
         terminal = Plugin.decky_terminal.get_terminal(id)
         if terminal is None:
             return None
-        
+
         return terminal.serialize()
 
     async def set_terminal_title(self, id: str, title: str) -> bool:
         Plugin.decky_terminal.set_terminal_title(id, title)
 
-    async def create_terminal(self, id = None) -> bool:
+    async def create_terminal(self, id=None) -> bool:
         if id is None:
-            id = "term_"+str(random.randint(100, 999))
-        
+            id = "term_" + str(random.randint(100, 999))
+
         await Plugin.decky_terminal.create_terminal(id)
         return True
 
@@ -57,10 +60,10 @@ class Plugin:
             return False
         except:
             return False
-    
+
     async def get_config(self) -> str:
         return await Plugin.decky_terminal.get_config()
-    
+
     async def append_config(self, config: dict) -> str:
         return await Plugin.decky_terminal.append_config(config)
 
@@ -75,12 +78,12 @@ class Plugin:
 
     # Asyncio-compatible long-running code, executed in a task when the plugin is loaded
     async def _main(self):
-        #decky_plugin.logger.info("Hello World!")
+        # decky_plugin.logger.info("Hello World!")
         await Plugin.decky_terminal.start_server()
 
     # Function called first during the unload process, utilize this to handle your plugin being removed
     async def _unload(self):
-        #decky_plugin.logger.info("Goodbye World!")
+        # decky_plugin.logger.info("Goodbye World!")
         await Plugin.decky_terminal.stop_server()
 
     # Migrations that should be performed before entering `_main()`.
@@ -91,10 +94,11 @@ class Plugin:
         await self._main()
         print(Plugin.decky_terminal.get_server_port())
 
-        await Plugin.decky_terminal.create_terminal('testterm')
-        print('testterm created.')
+        await Plugin.decky_terminal.create_terminal("testterm")
+        print("testterm created.")
 
-#plugin = Plugin()
-#loop = asyncio.get_event_loop()
-#asyncio.ensure_future(plugin._internal_test(), loop=loop)
-#loop.run_forever()
+
+# plugin = Plugin()
+# loop = asyncio.get_event_loop()
+# asyncio.ensure_future(plugin._internal_test(), loop=loop)
+# loop.run_forever()

--- a/main.py
+++ b/main.py
@@ -16,44 +16,44 @@ class Plugin:
         terminals = Plugin.decky_terminal.get_terminals()
         output = []
 
-        for id, terminal in terminals.items():
+        for terminal_id, terminal in terminals.items():
             result = terminal.serialize()
             output.append(
                 dict(
-                    id=id,
+                    id=terminal_id,
                     **result,
                 )
             )
 
         return output
 
-    async def get_terminal(self, id: str) -> Optional[dict]:
-        terminal = Plugin.decky_terminal.get_terminal(id)
+    async def get_terminal(self, terminal_id: str) -> Optional[dict]:
+        terminal = Plugin.decky_terminal.get_terminal(terminal_id)
         if terminal is None:
             return None
 
         return terminal.serialize()
 
-    async def set_terminal_title(self, id: str, title: str) -> bool:
-        Plugin.decky_terminal.set_terminal_title(id, title)
+    async def set_terminal_title(self, terminal_id: str, title: str) -> bool:
+        Plugin.decky_terminal.set_terminal_title(terminal_id, title)
 
-    async def create_terminal(self, id=None) -> bool:
-        if id is None:
-            id = "term_" + str(random.randint(100, 999))
+    async def create_terminal(self, terminal_id=None) -> bool:
+        if terminal_id is None:
+            terminal_id = "term_" + str(random.randint(100, 999))
 
-        await Plugin.decky_terminal.create_terminal(id)
+        await Plugin.decky_terminal.create_terminal(terminal_id)
         return True
 
-    async def remove_terminal(self, id) -> bool:
+    async def remove_terminal(self, terminal_id) -> bool:
         try:
-            await Plugin.decky_terminal.remove_terminal(id)
+            await Plugin.decky_terminal.remove_terminal(terminal_id)
             return True
         except:
             return False
 
-    async def change_terminal_window_size(self, id, rows: int, cols: int) -> bool:
+    async def change_terminal_window_size(self, terminal_id, rows: int, cols: int) -> bool:
         try:
-            terminal = Plugin.decky_terminal.get_terminal(id)
+            terminal = Plugin.decky_terminal.get_terminal(terminal_id)
             if terminal is not None:
                 await terminal.change_window_size(rows, cols)
                 return True

--- a/main.py
+++ b/main.py
@@ -1,11 +1,6 @@
 import random
 from typing import List, Optional
-
-try:
-    from decky_terminal import DeckyTerminal
-except Exception as e:
-    print('[DeckyTerminal] Import Failed:', type(e), e)
-    raise e
+from decky_terminal import DeckyTerminal
 
 class Plugin:
     decky_terminal = DeckyTerminal()

--- a/main.py
+++ b/main.py
@@ -18,12 +18,8 @@ class Plugin:
 
         for terminal_id, terminal in terminals.items():
             result = terminal.serialize()
-            output.append(
-                dict(
-                    id=terminal_id,
-                    **result,
-                )
-            )
+            result["id"] = terminal_id  # TODO: should a terminal own its ID?
+            output.append(result)
 
         return output
 

--- a/main.py
+++ b/main.py
@@ -1,12 +1,5 @@
-import sys
-import asyncio
 import random
 from typing import List, Optional
-
-try:
-    import decky_plugin
-except ImportError:
-    pass
 
 try:
     from decky_terminal import DeckyTerminal

--- a/main.py
+++ b/main.py
@@ -76,29 +76,11 @@ class Plugin:
     async def set_default_shell(self, shell: str) -> bool:
         return await Plugin.decky_terminal.set_default_shell(shell)
 
-    # Asyncio-compatible long-running code, executed in a task when the plugin is loaded
     async def _main(self):
-        # decky_plugin.logger.info("Hello World!")
         await Plugin.decky_terminal.start_server()
 
-    # Function called first during the unload process, utilize this to handle your plugin being removed
     async def _unload(self):
-        # decky_plugin.logger.info("Goodbye World!")
         await Plugin.decky_terminal.stop_server()
 
-    # Migrations that should be performed before entering `_main()`.
     async def _migration(self):
         pass
-
-    async def _internal_test(self):
-        await self._main()
-        print(Plugin.decky_terminal.get_server_port())
-
-        await Plugin.decky_terminal.create_terminal("testterm")
-        print("testterm created.")
-
-
-# plugin = Plugin()
-# loop = asyncio.get_event_loop()
-# asyncio.ensure_future(plugin._internal_test(), loop=loop)
-# loop.run_forever()

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import random
 from typing import List, Optional
 from decky_terminal import DeckyTerminal
 
@@ -34,9 +33,6 @@ class Plugin:
         Plugin.decky_terminal.set_terminal_title(terminal_id, title)
 
     async def create_terminal(self, terminal_id=None) -> bool:
-        if terminal_id is None:
-            terminal_id = "term_" + str(random.randint(100, 999))
-
         await Plugin.decky_terminal.create_terminal(terminal_id)
         return True
 


### PR DESCRIPTION
I got a little carried away, so this all ended up in one single commit. Raising as a draft until I can unpick it into some reasonable suggestions. Though feel free to cherry pick what matters to you.

It's also completely untested, but is thoroughly linted so I hopefully haven't done anything completely silly.

Some key changes:

* Rewrite terminal ID handling (picking up your todo) to use the stl urllib.parse, then split the path on "/" and grab the last element
* Move terminal ID creation into Terminal, and make it based on a UUID so it can't get potluck conflicting IDs (random has a tendency of not being random enough)
* Rewrite started, completed and alive to be a little more concise
* Try to use an explicit `encode("utf-8")` instead of a blunt convert to `bytes()`
* Try to make `get_terminal_env` a little cleaner
* Remove `Optional` from `cmdline` class variable, since `cmdline` is used regardless and could be undefined (raising an `AttributeError`)
* Rename from variables away from Python builtins (`min`, `id`) to avoid future mishaps